### PR TITLE
SPPF terminal nodes

### DIFF
--- a/src/AST.Common/ASTGLLFSA.fs
+++ b/src/AST.Common/ASTGLLFSA.fs
@@ -47,6 +47,8 @@ type NonTerminalNode =
 and TerminalNode =
     val Name : int<token>
     val Extension : int64<extension>
+    member this.getRightExtension = int <| ((int64 this.Extension) &&& 0xffffffffL)
+    member this.getLeftExtension = int <| ((int64 this.Extension) >>> 32)
     interface INode with
         member this.getExtension () = this.Extension
     new (name, extension) = {Name = name; Extension = extension}

--- a/src/AST.Common/ASTGLLFSA.fs
+++ b/src/AST.Common/ASTGLLFSA.fs
@@ -47,8 +47,6 @@ type NonTerminalNode =
 and TerminalNode =
     val Name : int<token>
     val Extension : int64<extension>
-    member this.getRightExtension = int <| ((int64 this.Extension) &&& 0xffffffffL)
-    member this.getLeftExtension = int <| ((int64 this.Extension) >>> 32)
     interface INode with
         member this.getExtension () = this.Extension
     new (name, extension) = {Name = name; Extension = extension}

--- a/src/GLLAbstractParser/SPPF.fs
+++ b/src/GLLAbstractParser/SPPF.fs
@@ -203,5 +203,5 @@ type SPPF(lengthOfInput : int, startState : int<positionInGrammar>, finalStates 
                              | _ -> failwith "wrongType")
         |> Array.ofSeq
 
-let GetPathSet (sppf : SPPF) = 
-    sppf.GetTerminalNodes |> Seq.map (fun x -> x.Name, x.getLeftExtension, x.getRightExtension)
+let GetTerminals (sppf : SPPF) = 
+    sppf.GetTerminalNodes |> Seq.map (fun x -> x.Name, getLeftExtension x.Extension, getRightExtension x.Extension)

--- a/src/GLLAbstractParser/SPPF.fs
+++ b/src/GLLAbstractParser/SPPF.fs
@@ -62,6 +62,9 @@ type SPPF(lengthOfInput : int, startState : int<positionInGrammar>, finalStates 
     member this.EpsilonNodes = epsilonNodes
     member this.PackedNodes = packedNodes
 
+    member this.GetTerminalNodes = 
+        this.Nodes |> Seq.filter (fun x -> x :? TerminalNode) |> Seq.cast<TerminalNode>
+
     member this.FindSppfNode (t : TypeOfNode) lExt rExt : int<nodeMeasure> =
         match t with 
         | Nonterm state ->
@@ -115,8 +118,6 @@ type SPPF(lengthOfInput : int, startState : int<positionInGrammar>, finalStates 
         let newNode = createNode()
 //        packedNodes.Add(key, newNode)
         newNode
-
-    
 
     member this.GetNodeT (symbol : int<token>) (pos : int<positionInInput>) (nextPos : int<positionInInput>) =
         let index = int pos + 1
@@ -201,3 +202,6 @@ type SPPF(lengthOfInput : int, startState : int<positionInGrammar>, finalStates 
                              | TreeNode n -> this.Nodes.Item (int n)
                              | _ -> failwith "wrongType")
         |> Array.ofSeq
+
+let GetPathSet (sppf : SPPF) = 
+    sppf.GetTerminalNodes |> Seq.map (fun x -> x.Name, x.getLeftExtension, x.getRightExtension)


### PR DESCRIPTION
Если я всё правильно понял, то теперь можно вытащить из SPPF все терминальные ноды и получить тройки в духе (token, startVertice, endVertice).