### PR TITLE
Grammar combinator v0.3.1

### DIFF
--- a/src/Common/IL.fs
+++ b/src/Common/IL.fs
@@ -145,7 +145,10 @@ and Production<'patt,'expr> =
         |PMetaRef (name, args, metaArgs) ->
             sourceToString name + metaArgsToString metaArgs + argsToString args
         |PLiteral src -> sourceToString src
-        |PRepet _ -> failwith "Repetition was not realized yet"
+        |PRepet(p, None, None) -> PMany(p).ToString()
+        |PRepet(p, None, Some n) -> sprintf "(%O){0..%O}" p n
+        |PRepet(p, Some m, None) -> sprintf "(%O){%O..inf}" p m
+        |PRepet(p, Some m, Some n) -> sprintf "(%O){%O..%O}" p m n
         |PPerm src ->
             src
             |> List.map (fun x -> x.ToString())

--- a/src/GrammarCombinator/Combinators.fs
+++ b/src/GrammarCombinator/Combinators.fs
@@ -13,6 +13,10 @@ module Combinators =
     let internal getProd = function Product(_, p) -> p
     let private mkProd = untuple Product None
 
+    type Product with
+        static member (%) (p, (m, n)) = Production.PRepet(getProd p, Some m, Some n)
+        static member (%) (p, (m)) = Production.PRepet(getProd p, Some m, None)
+
     let private applyBinop op a b = mkProd <| op (getProd a) (getProd b)
     let private applyUnaryop op = getProd >> op >> mkProd
 

--- a/src/GrammarCombinator/Combinators.fs
+++ b/src/GrammarCombinator/Combinators.fs
@@ -74,7 +74,6 @@ module internal Core =
         | IfThenElse(p, t1, t2) -> Expr.IfThenElse(fixExpression p, fixExpression t1, fixExpression t2)
         | NewObject(cinfo, exprs) -> Expr.NewObject(cinfo, List.map fixExpression exprs)
         | AddressOf expr -> Expr.AddressOf <| fixExpression expr
-        | QuoteRaw expr -> Expr.QuoteRaw <| fixExpression expr
         | AddressSet(left, right) -> Expr.AddressSet(fixExpression left, fixExpression right)
         | Sequential(left, right) -> Expr.Sequential(fixExpression left, fixExpression right)
         | TryFinally(tryblock, finalblock) -> Expr.TryFinally(fixExpression tryblock, fixExpression finalblock)
@@ -108,6 +107,7 @@ module internal Core =
         | PropertySet(None, pinfo, exprs, expr) -> Expr.PropertySet(pinfo, fixExpression expr, List.map fixExpression exprs)
         | PropertySet(Some prop, pinfo, exprs, expr) ->
             Expr.PropertySet(fixExpression prop, pinfo, fixExpression expr, List.map fixExpression exprs)
+        | Quote _ as expr -> failwithf "Cannot use Quotations inside Quotations! %O" expr
         | t -> failwithf "Internal error. Please report this object to developer team: %O" t
 
     let fixTree (expr: Expr<Product>) : Expr = fixExpression expr.Raw

--- a/src/GrammarCombinator/Combinators.fs
+++ b/src/GrammarCombinator/Combinators.fs
@@ -116,7 +116,7 @@ module internal Core =
 
 
     // --------------------------------------------- POSTPROCESSING ---------------------------------------------
-    let productToGrammar start : Product -> GrammarDefinition =
+    let productToGrammar start =
         let inline mkName name uid = name + "$" + uid.ToString()
         let inline mkPRef name uid = PRef(Source <| mkName name uid, None)
 
@@ -164,7 +164,7 @@ module GrammarGenerator =
     open Combinators
     open Core
 
-    let generate (name: string) : Expr<Product> -> GrammarDefinition =
+    let generate (name: string) =
         fixTree
         >> QuotationEvaluator.EvaluateUntyped
         >> (fun x -> x :?> Product)

--- a/src/GrammarCombinator/Combinators.fs
+++ b/src/GrammarCombinator/Combinators.fs
@@ -73,13 +73,44 @@ module internal Core =
                 then <@@ fun (_: unit) -> Product(None, pref %%op) @@>
                 else fixExpression op
                 , fixExpression args)
-        | PropertyGet(None, info, args) ->
-            Expr.PropertyGet(info, List.map fixExpression args)
-        | Call(None, op, args) ->
-            Expr.Call(op, List.map fixExpression args)
-        | IfThenElse(p, t1, t2) ->
-            Expr.IfThenElse(fixExpression p, fixExpression t1, fixExpression t2)
-        | t -> t // TODO: all Expressions
+        | IfThenElse(p, t1, t2) -> Expr.IfThenElse(fixExpression p, fixExpression t1, fixExpression t2)
+        | NewObject(cinfo, exprs) -> Expr.NewObject(cinfo, List.map fixExpression exprs)
+        | AddressOf expr -> Expr.AddressOf <| fixExpression expr
+        | QuoteRaw expr -> Expr.QuoteRaw <| fixExpression expr
+        | AddressSet(left, right) -> Expr.AddressSet(fixExpression left, fixExpression right)
+        | Sequential(left, right) -> Expr.Sequential(fixExpression left, fixExpression right)
+        | TryFinally(tryblock, finalblock) -> Expr.TryFinally(fixExpression tryblock, fixExpression finalblock)
+        | WhileLoop(cond, body) -> Expr.WhileLoop(fixExpression cond, fixExpression body)
+        | Coerce(expr, tp) -> Expr.Coerce(fixExpression expr, tp)
+        | TypeTest(expr, tp) -> Expr.TypeTest(fixExpression expr, tp)
+        | UnionCaseTest(expr, uinfo) -> Expr.UnionCaseTest(fixExpression expr, uinfo)
+        | TryWith(body, filterVar, filterBody, catchVar, catchBody) ->
+            Expr.TryWith(fixExpression body, filterVar, fixExpression filterBody, catchVar, fixExpression catchBody)
+        | TupleGet(expr, ind) -> Expr.TupleGet(fixExpression expr, ind)
+        | NewTuple exprs -> Expr.NewTuple <| List.map fixExpression exprs
+        | NewArray(tp, exprs) -> Expr.NewArray(tp, List.map fixExpression exprs)
+        | NewRecord(tp, exprs) -> Expr.NewRecord(tp, List.map fixExpression exprs)
+        | NewDelegate(tp, vrs, expr) -> Expr.NewDelegate(tp, vrs, fixExpression expr)
+        | NewUnionCase(uinfo, exprs) -> Expr.NewUnionCase(uinfo, List.map fixExpression exprs)
+        | DefaultValue _ as dv -> dv
+        | Var _ as vr -> vr
+        | Value _ as vl -> vl
+        | Lambda(vr, expr) -> Expr.Lambda(vr, fixExpression expr)
+        | VarSet(vr, expr) -> Expr.VarSet(vr, fixExpression expr)
+        | ForIntegerRangeLoop(loopVariable, start, endExpr, body) ->
+            Expr.ForIntegerRangeLoop(loopVariable, fixExpression start, fixExpression endExpr, fixExpression body)
+        | Call(None, op, args) -> Expr.Call(op, List.map fixExpression args)
+        | Call(Some expr, op, args) -> Expr.Call(fixExpression expr, op, List.map fixExpression args)
+        | FieldGet(None, _) as fg -> fg
+        | FieldGet(Some expr, finfo) -> Expr.FieldGet(fixExpression expr, finfo)
+        | FieldSet(None, finfo, expr) -> Expr.FieldSet(finfo, fixExpression expr)
+        | FieldSet(Some fld, finfo, expr) -> Expr.FieldSet(fixExpression fld, finfo, fixExpression expr)
+        | PropertyGet(None, pinfo, args) -> Expr.PropertyGet(pinfo, List.map fixExpression args)
+        | PropertyGet(Some expr, pinfo, exprs) -> Expr.PropertyGet(fixExpression expr, pinfo, List.map fixExpression exprs)
+        | PropertySet(None, pinfo, exprs, expr) -> Expr.PropertySet(pinfo, fixExpression expr, List.map fixExpression exprs)
+        | PropertySet(Some prop, pinfo, exprs, expr) ->
+            Expr.PropertySet(fixExpression prop, pinfo, fixExpression expr, List.map fixExpression exprs)
+        | t -> failwithf "Internal error. Please report this object to developer team: %O" t
 
     let fixTree (expr: Expr<Product>) : Expr = fixExpression expr.Raw
 

--- a/src/GrammarCombinator/FeatureExamples.fs
+++ b/src/GrammarCombinator/FeatureExamples.fs
@@ -12,7 +12,7 @@ module TestSuite =
     open Yard.Generators.GLL
     open AbstractAnalysis.Common
 
-    let private psgll (def: GrammarDefinition) : ParserCommon.ParserSourceGLL =
+    let private psgll def : ParserCommon.ParserSourceGLL =
         let gll = new GLL() in
         gll.Generate(def, false) :?> ParserCommon.ParserSourceGLL
 

--- a/src/GrammarCombinator/SimpleILWrapper.fs
+++ b/src/GrammarCombinator/SimpleILWrapper.fs
@@ -6,7 +6,6 @@ module internal Shortcuts =
     type Production<'a> = Production<Source, 'a>
     type Rule = Rule<Source, Source>
     type Grammar = Grammar<Source, Source>
-    type GrammarDefinition = Definition<Source, Source>
     let Source x = new Source(x)
     let fail() = failwith "Internal Fail"
     let __unreachable__() = failwith "Unreachable branch hit"
@@ -64,4 +63,4 @@ module internal IL =
     let grammar (rules: list<Rule>) : Grammar =
         List.map (fun r -> {r with allPublic = true}) (Yard.Core.Helpers.defaultModules rules)
 
-    let definition (g: Grammar) : GrammarDefinition = {emptyGrammarDefinition with grammar = g}
+    let definition (g: Grammar) : Definition<Source, Source> = {emptyGrammarDefinition with grammar = g}

--- a/src/GrammarCombinator/SimpleILWrapper.fs
+++ b/src/GrammarCombinator/SimpleILWrapper.fs
@@ -34,6 +34,30 @@ module internal IL =
             | _ -> [prodElem x; prodElem y]
         PSeq(xys, None, None)
 
+    let (|BinaryIL|_|) prod =
+        let getBinOp = function
+            | PShuff _ -> PShuff
+            | PAlt _ -> PAlt
+            | PConj _ -> PConj
+        match prod with
+        | PShuff(l, r)
+        | PAlt(l, r)
+        | PConj(l, r) -> Some((fun x y -> getBinOp prod (x, y)), l, r)
+        | _ -> None
+
+    let (|UnaryIL|_|) prod =
+        let getUnaryOp = function
+            | PNeg _ -> PNeg
+            | PMany _ -> PMany
+            | PSome _ -> PSome
+            | POpt _ -> POpt
+        match prod with
+            | PNeg p
+            | PMany p
+            | PSome p
+            | POpt p -> Some(getUnaryOp prod, p)
+            | _ -> None
+
     let rule (name: string) (p: Production<Source>) (isStart: bool) : Rule =
         {defaultRule (Source name) p with isStart = isStart; isPublic = true}
 


### PR DESCRIPTION
- All expressions handled
- Permutation syntax (`x % (3, 6)`)
- [Documentation](https://docs.google.com/document/d/1MEavgRFag6x6UvLjyyev6ttoMqYXyJ7-R25Here2xxs/edit?usp=sharing)