### PR TITLE
Always generating the same name for the whole grammar.

### DIFF
--- a/src/GrammarCombinator/Combinators.fs
+++ b/src/GrammarCombinator/Combinators.fs
@@ -158,7 +158,10 @@ module internal Core =
                     Wrapper.IL.rule (mkName name uid) prod true :: rules)
                 | _ -> __unreachable__()
 
-            assignProd start >> collectRulesFromProduct
+            let startProd name =
+                fun p -> Product(Some(name, 0), getProd p)            
+
+            startProd start >> collectRulesFromProduct
 
         collectRules >> Wrapper.IL.grammar >> Wrapper.IL.definition
 


### PR DESCRIPTION
Always generating a name like `unique$0` when calling `GrammarCombinator.GrammarGenerator.generate "unique" grammar`.

Otherwise it's impossible to use generated grammar with SPPF like this
```fsharp
let nt = sppf.GetNonTermByName "unique$0" ps
sppf.Iterate nt ps maxLength
```
repeatedly, as each invocation would have unpredictable number at the end.